### PR TITLE
Fixed memory access issue in enum_window callback

### DIFF
--- a/cheat/src/utils/mod.rs
+++ b/cheat/src/utils/mod.rs
@@ -51,9 +51,9 @@ unsafe extern "system" fn enum_window(window: HWND, lparam: LPARAM) -> BOOL {
         return TRUE;
     }
 
-    let lparam = std::mem::transmute::<_, *mut HWND>(lparam);
+    let lparam_ptr = lparam.0 as *mut HWND;
 
-    *lparam = window;
+    std::ptr::write(lparam_ptr, window);
 
     FALSE
 }


### PR DESCRIPTION
Fixed an issue where memory writes to ```lparam``` were being optimized away by the compiler.
Ensured proper memory access by using ```std::ptr::write``` to prevent reordering and guarantee correct write operations.