### PR TITLE
Switch to using retour for better cross-platform support

### DIFF
--- a/cheat/Cargo.toml
+++ b/cheat/Cargo.toml
@@ -18,7 +18,6 @@ crate-type = ["cdylib"]
 path = "src/entry_point.rs"
 
 [dependencies]
-minhook-sys = "0.1.1"
 lazy_static = "1.5"
 once_cell = "1.19"
 paste = "1.0"
@@ -32,6 +31,7 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 thiserror = "1.0.63"
 iced-x86 = "1.21.0"
+retour = "0.3.1"
 
 [dependencies.windows]
 version = "0.51.0"

--- a/cheat/src/core/hooks/mod.rs
+++ b/cheat/src/core/hooks/mod.rs
@@ -77,11 +77,6 @@ unsafe extern "system" fn hk_create_move(
 ///
 /// If `MinHook` fails to initialize, an error is returned with a message indicating the failure.
 pub fn initialize_hooks() -> anyhow::Result<()> {
-    // Initialize MinHook
-    if let Err(status) = utils::hook_system::initialize_minhook() {
-        bail!("failed to initialize MinHook: {status}");
-    }
-
     // Find the target addresses for the game functions
     let create_move_target = cs2::modules::client()
         .find_seq_of_bytes("48 8B C4 4C 89 48 20 55")


### PR DESCRIPTION
I'm planning on adding Linux support if you're open to it. I tested it on Windows and the behavior hasn't changed. Using retour also has the advantage of being written in Rust, so it's one less system dependency :)